### PR TITLE
Add axios token handling service

### DIFF
--- a/src/app/(main)/auth/_components/login-form.tsx
+++ b/src/app/(main)/auth/_components/login-form.tsx
@@ -11,9 +11,9 @@ import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { loginSchema, LoginFormData } from "@/lib/auth-schemas";
+import { loginSchema } from "@/lib/auth-schemas";
 import { authService } from "@/lib/auth-service";
-import { setAuthCookie } from "@/lib/auth-cookies";
+import { tokenService } from "@/lib/token-service";
 
 const FormSchema = loginSchema.extend({
   remember: z.boolean().optional(),
@@ -41,13 +41,13 @@ export function LoginForm() {
         email: data.email,
         password: data.password,
       });
-      if (response.success !== false && response.accessToken) {
-        setAuthCookie(
-          response.accessToken,
-          response.refreshToken,
-          response.tokenType,
-          response.expiresIn
-        );
+      if (response.success !== false && response.accessToken && response.refreshToken) {
+        tokenService.setTokens({
+          accessToken: response.accessToken,
+          refreshToken: response.refreshToken,
+          tokenType: response.tokenType,
+          expiresIn: response.expiresIn,
+        });
         toast.success("Giriş başarılı! Yönlendiriliyorsunuz...");
         router.push("/dashboard");
       } else {

--- a/src/app/(main)/auth/_components/register-form.tsx
+++ b/src/app/(main)/auth/_components/register-form.tsx
@@ -10,7 +10,6 @@ import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "
 import { Input } from "@/components/ui/input";
 import { registerSchema, RegisterFormData } from "@/lib/auth-schemas";
 import { authService } from "@/lib/auth-service";
-import { setAuthCookie } from "@/lib/auth-cookies";
 
 export function RegisterForm() {
   const router = useRouter();

--- a/src/app/(main)/dashboard/patients/_components/patient-card-grid.tsx
+++ b/src/app/(main)/dashboard/patients/_components/patient-card-grid.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react";
 import { getPatients } from "../_services/patient-service";
 import { PatientCard } from "./patient-card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { getAuthCookie } from "@/lib/auth-cookies";
 
 export interface Patient {
   id: string;
@@ -20,10 +19,7 @@ export function PatientCardGrid() {
   const [patients, setPatients] = useState<Patient[] | null>(null);
 
   useEffect(() => {
-    const token = getAuthCookie();
-    if (!token) return;
-
-    getPatients(token).then((res) => setPatients(res.items));
+    getPatients().then((res) => setPatients(res.items));
   }, []);
 
   if (!patients) return <Skeleton className="h-[400px] w-full" />;

--- a/src/app/(main)/dashboard/patients/_components/patient-card-grid.tsx
+++ b/src/app/(main)/dashboard/patients/_components/patient-card-grid.tsx
@@ -17,10 +17,13 @@ export interface Patient {
 
 export function PatientCardGrid() {
   const [patients, setPatients] = useState<Patient[] | null>(null);
+  const [refreshKey, setRefreshKey] = useState(0); // 🔁 refresh tetikleyici
 
   useEffect(() => {
     getPatients().then((res) => setPatients(res.items));
-  }, []);
+  }, [refreshKey]); // refreshKey değiştikçe yeniden fetch eder
+
+  const refresh = () => setRefreshKey((prev) => prev + 1);
 
   if (!patients) return <Skeleton className="h-[400px] w-full" />;
   if (patients.length === 0) return <p className="text-muted-foreground">Danışan bulunamadı.</p>;
@@ -28,7 +31,7 @@ export function PatientCardGrid() {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
       {patients.map((patient) => (
-        <PatientCard key={patient.id} patient={patient} />
+        <PatientCard key={patient.id} patient={patient} onRefresh={refresh} />
       ))}
     </div>
   );

--- a/src/app/(main)/dashboard/patients/_components/patient-dialog.tsx
+++ b/src/app/(main)/dashboard/patients/_components/patient-dialog.tsx
@@ -23,10 +23,7 @@ export function PatientDialog({ open, onOpenChange, patient }: Props) {
     if (!patient?.id) return;
 
     try {
-      const token = localStorage.getItem("auth-token");
-      if (!token) throw new Error("Token eksik");
-
-      await deletePatient(patient.id, token);
+      await deletePatient(patient.id);
       toast.success("Danışan silindi");
       onOpenChange(false);
     } catch (err: any) {

--- a/src/app/(main)/dashboard/patients/_components/patient-form.tsx
+++ b/src/app/(main)/dashboard/patients/_components/patient-form.tsx
@@ -9,6 +9,8 @@ import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "sonner";
 import { createPatient, updatePatient } from "../_services/patient-service";
+import { useRouter } from "next/navigation";
+
 
 const schema = z.object({
   name: z.string().min(2),
@@ -25,6 +27,8 @@ export function PatientForm({
   patient?: any;
   onSuccess?: () => void;
 }) {
+    const router = useRouter();
+
   const form = useForm({
     resolver: zodResolver(schema),
     defaultValues: patient ?? {
@@ -46,6 +50,7 @@ export function PatientForm({
         toast.success("Danışan eklendi");
       }
 
+      router.refresh();
       onSuccess?.();
     } catch (err: any) {
       toast.error(err.message ?? "İşlem başarısız");

--- a/src/app/(main)/dashboard/patients/_components/patient-form.tsx
+++ b/src/app/(main)/dashboard/patients/_components/patient-form.tsx
@@ -38,14 +38,11 @@ export function PatientForm({
 
   const onSubmit = async (values: any) => {
     try {
-      const token = localStorage.getItem("auth-token");
-      if (!token) throw new Error("Token bulunamadı");
-
       if (patient) {
-        await updatePatient(patient.id, values, token);
+        await updatePatient(patient.id, values);
         toast.success("Danışan güncellendi");
       } else {
-        await createPatient(values, token);
+        await createPatient(values);
         toast.success("Danışan eklendi");
       }
 

--- a/src/app/(main)/dashboard/patients/_services/patient-service.ts
+++ b/src/app/(main)/dashboard/patients/_services/patient-service.ts
@@ -1,54 +1,23 @@
-const BASE_URL = "https://localhost:5001/api/patients";
+import api from '@/lib/axios';
 
-export async function getPatients(token: string) {
-  const res = await fetch(`${BASE_URL}?PageNumber=1&PageSize=10`, {
-    headers: {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-  });
+const BASE_URL = '/patients';
 
-  if (!res.ok) throw new Error("Danışanlar alınamadı");
-  return res.json();
+export async function getPatients() {
+  const res = await api.get(`${BASE_URL}`, { params: { PageNumber: 1, PageSize: 10 } });
+  return res.data;
 }
 
-export async function createPatient(data: any, token: string) {
-  const res = await fetch(BASE_URL, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify(data),
-  });
-
-  if (!res.ok) throw new Error("Danışan eklenemedi");
-  return res.json();
+export async function createPatient(data: any) {
+  const res = await api.post(BASE_URL, data);
+  return res.data;
 }
 
-export async function updatePatient(id: string, data: any, token: string) {
-  const res = await fetch(`${BASE_URL}/${id}`, {
-    method: "PUT",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${token}`,
-    },
-    body: JSON.stringify(data),
-  });
-
-  if (!res.ok) throw new Error("Danışan güncellenemedi");
-  return res.json();
+export async function updatePatient(id: string, data: any) {
+  const res = await api.put(`${BASE_URL}/${id}`, data);
+  return res.data;
 }
 
-export async function deletePatient(id: string, token: string) {
-  const res = await fetch(`${BASE_URL}/${id}`, {
-    method: "DELETE",
-    headers: {
-      Authorization: `Bearer ${token}`,
-    },
-  });
-
-  if (!res.ok) throw new Error("Danışan silinemedi");
+export async function deletePatient(id: string) {
+  await api.delete(`${BASE_URL}/${id}`);
   return true;
 }

--- a/src/config/app-config.ts
+++ b/src/config/app-config.ts
@@ -12,6 +12,6 @@ export const APP_CONFIG = {
       "Fidi Admin is a modern, open-source dashboard starter template built with Next.js 15, Tailwind CSS v4, and shadcn/ui. Perfect for SaaS apps, admin panels, and internal tools—fully customizable and production-ready.",
   },
   api: {
-    baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:5000',
+    baseUrl: process.env.NEXT_PUBLIC_API_BASE_URL || 'https://localhost:5001/api',
   },
 };

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
-import { getAuthCookie, removeAuthCookie } from "@/lib/auth-cookies";
+import { tokenService } from "@/lib/token-service";
 
 export const useAuth = () => {
   const [isAuthenticated, setIsAuthenticated] = useState<boolean | null>(null);
@@ -10,7 +10,7 @@ export const useAuth = () => {
   const router = useRouter();
 
   useEffect(() => {
-    const authToken = getAuthCookie();
+    const authToken = tokenService.getAccessToken();
     if (authToken) {
       setToken(authToken);
       setIsAuthenticated(true);
@@ -20,7 +20,7 @@ export const useAuth = () => {
   }, []);
 
   const logout = () => {
-    removeAuthCookie();
+    tokenService.clearTokens();
     setToken(null);
     setIsAuthenticated(false);
     router.push("/auth/login");

--- a/src/lib/auth-service.ts
+++ b/src/lib/auth-service.ts
@@ -1,13 +1,6 @@
-import axios from "axios";
-import { APP_CONFIG } from "@/config/app-config";
-import { LoginFormData, RegisterFormData } from "./auth-schemas";
-
-const api = axios.create({
-  baseURL: APP_CONFIG.api.baseUrl,
-  headers: {
-    "Content-Type": "application/json",
-  },
-});
+import axios from 'axios';
+import { LoginFormData, RegisterFormData } from './auth-schemas';
+import api from './axios';
 
 export interface AuthResponse {
   success?: boolean; // opsiyonel, backend döndürmüyor olabilir
@@ -46,6 +39,20 @@ export const authService = {
         throw new Error(error.response.data.message);
       }
       throw new Error("Kayıt olurken bir hata oluştu. Lütfen tekrar deneyin.");
+    }
+  },
+
+  async refreshToken(refreshToken: string): Promise<AuthResponse> {
+    try {
+      const response = await api.post<AuthResponse>('/refresh', {
+        refreshToken,
+      });
+      return response.data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.data?.message) {
+        throw new Error(error.response.data.message);
+      }
+      throw new Error('Token yenilenemedi');
     }
   },
 };

--- a/src/lib/auth-service.ts
+++ b/src/lib/auth-service.ts
@@ -20,7 +20,7 @@ export interface AuthResponse {
 export const authService = {
   async login(data: LoginFormData): Promise<AuthResponse> {
     try {
-      const response = await api.post<AuthResponse>("/login", data);
+      const response = await api.post<AuthResponse>("/auth/login", data);
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error) && error.response?.data?.message) {
@@ -32,7 +32,7 @@ export const authService = {
 
   async register(data: RegisterFormData): Promise<AuthResponse> {
     try {
-      const response = await api.post<AuthResponse>("/register", data);
+      const response = await api.post<AuthResponse>("/auth/register", data);
       return response.data;
     } catch (error) {
       if (axios.isAxiosError(error) && error.response?.data?.message) {
@@ -44,7 +44,7 @@ export const authService = {
 
   async refreshToken(refreshToken: string): Promise<AuthResponse> {
     try {
-      const response = await api.post<AuthResponse>('/refresh', {
+      const response = await api.post<AuthResponse>('/auth/refresh', {
         refreshToken,
       });
       return response.data;

--- a/src/lib/axios.ts
+++ b/src/lib/axios.ts
@@ -1,0 +1,74 @@
+import axios, { AxiosError, AxiosRequestConfig } from 'axios';
+import { APP_CONFIG } from '@/config/app-config';
+import { tokenService } from './token-service';
+import { authService } from './auth-service';
+
+const api = axios.create({
+  baseURL: APP_CONFIG.api.baseUrl,
+});
+
+let isRefreshing = false;
+let failedQueue: { resolve: (value?: unknown) => void; config: AxiosRequestConfig }[] = [];
+
+function processQueue(token: string | null) {
+  failedQueue.forEach((p) => {
+    if (token && p.config.headers) {
+      p.config.headers.Authorization = `Bearer ${token}`;
+    }
+    p.resolve(api(p.config));
+  });
+  failedQueue = [];
+}
+
+api.interceptors.request.use((config) => {
+  const token = tokenService.getAccessToken();
+  if (token && config.headers) {
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error: AxiosError) => {
+    const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean };
+    if (error.response?.status === 401 && !originalRequest._retry) {
+      originalRequest._retry = true;
+
+      if (isRefreshing) {
+        return new Promise((resolve) => {
+          failedQueue.push({ resolve, config: originalRequest });
+        });
+      }
+
+      isRefreshing = true;
+      try {
+        const refreshed = await authService.refreshToken(tokenService.getRefreshToken() ?? '');
+        if (refreshed.accessToken && refreshed.refreshToken) {
+          tokenService.setTokens({
+            accessToken: refreshed.accessToken,
+            refreshToken: refreshed.refreshToken,
+            tokenType: refreshed.tokenType,
+            expiresIn: refreshed.expiresIn,
+          });
+          processQueue(refreshed.accessToken);
+          originalRequest.headers = originalRequest.headers || {};
+          originalRequest.headers.Authorization = `Bearer ${refreshed.accessToken}`;
+          return api(originalRequest);
+        }
+        throw new Error('Unable to refresh token');
+      } catch (refreshError) {
+        tokenService.clearTokens();
+        if (typeof window !== 'undefined') {
+          window.location.href = '/auth/login';
+        }
+        return Promise.reject(refreshError);
+      } finally {
+        isRefreshing = false;
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default api;

--- a/src/lib/token-service.ts
+++ b/src/lib/token-service.ts
@@ -1,0 +1,36 @@
+export interface TokenData {
+  accessToken: string;
+  refreshToken: string;
+  tokenType?: string;
+  expiresIn?: number;
+}
+
+const ACCESS_KEY = 'access-token';
+const REFRESH_KEY = 'refresh-token';
+const TYPE_KEY = 'token-type';
+const EXPIRES_KEY = 'expires-in';
+
+export const tokenService = {
+  getAccessToken(): string | null {
+    if (typeof window === 'undefined') return null;
+    return localStorage.getItem(ACCESS_KEY);
+  },
+  getRefreshToken(): string | null {
+    if (typeof window === 'undefined') return null;
+    return localStorage.getItem(REFRESH_KEY);
+  },
+  setTokens(data: TokenData): void {
+    if (typeof window === 'undefined') return;
+    localStorage.setItem(ACCESS_KEY, data.accessToken);
+    localStorage.setItem(REFRESH_KEY, data.refreshToken);
+    if (data.tokenType) localStorage.setItem(TYPE_KEY, data.tokenType);
+    if (data.expiresIn) localStorage.setItem(EXPIRES_KEY, data.expiresIn.toString());
+  },
+  clearTokens(): void {
+    if (typeof window === 'undefined') return;
+    localStorage.removeItem(ACCESS_KEY);
+    localStorage.removeItem(REFRESH_KEY);
+    localStorage.removeItem(TYPE_KEY);
+    localStorage.removeItem(EXPIRES_KEY);
+  },
+};


### PR DESCRIPTION
## Summary
- centralize token storage in `token-service`
- create axios instance with automatic auth headers and refresh handling
- expose refreshToken call in `auth-service`
- refactor login to persist tokens via the service
- update hooks and patient features to use axios client

## Testing
- `npm run lint` *(fails: Next.js plugin missing and code style warnings)*
- `npm run format:check` *(fails: code style issues found)*

------
https://chatgpt.com/codex/tasks/task_e_687614319844832090fff7e1beaa0eff