### PR TITLE
Fix patient list refresh and pagination

### DIFF
--- a/src/app/(main)/dashboard/patients/_components/patient-card-grid.tsx
+++ b/src/app/(main)/dashboard/patients/_components/patient-card-grid.tsx
@@ -3,8 +3,14 @@
 import { useState } from "react";
 import { PatientCard } from "./patient-card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { Button } from "@/components/ui/button";
 import { usePatients } from "@/hooks/use-patients";
+import {
+  Pagination,
+  PaginationContent,
+  PaginationItem,
+  PaginationPrevious,
+  PaginationNext,
+} from "@/components/ui/pagination";
 
 export interface Patient {
   id: string;
@@ -28,22 +34,35 @@ export function PatientCardGrid() {
   return (
     <>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {patients.map((patient) => (
+        {patients.map((patient: Patient) => (
           <PatientCard key={patient.id} patient={patient} />
         ))}
       </div>
-      <div className="mt-4 flex justify-center gap-2">
-        <Button variant="outline" disabled={page === 1} onClick={() => setPage((p) => p - 1)}>
-          Önceki
-        </Button>
-        <Button
-          variant="outline"
-          disabled={data && page >= (data.totalPages ?? page)}
-          onClick={() => setPage((p) => p + 1)}
-        >
-          Sonraki
-        </Button>
-      </div>
+      <Pagination className="mt-4">
+        <PaginationContent>
+          <PaginationItem>
+            <PaginationPrevious
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                setPage((p) => Math.max(1, p - 1));
+              }}
+              className={page === 1 ? "pointer-events-none opacity-50" : ""}
+            />
+          </PaginationItem>
+          <PaginationItem>
+            <PaginationNext
+              href="#"
+              onClick={(e) => {
+                e.preventDefault();
+                if (!data || page >= (data.totalPages ?? page)) return;
+                setPage((p) => p + 1);
+              }}
+              className={data && page >= (data.totalPages ?? page) ? "pointer-events-none opacity-50" : ""}
+            />
+          </PaginationItem>
+        </PaginationContent>
+      </Pagination>
     </>
   );
 }

--- a/src/app/(main)/dashboard/patients/_components/patient-card-grid.tsx
+++ b/src/app/(main)/dashboard/patients/_components/patient-card-grid.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { getPatients } from "../_services/patient-service";
+import { useState } from "react";
 import { PatientCard } from "./patient-card";
 import { Skeleton } from "@/components/ui/skeleton";
-import { getAuthCookie } from "@/lib/auth-cookies";
+import { Button } from "@/components/ui/button";
+import { usePatients } from "@/hooks/use-patients";
 
 export interface Patient {
   id: string;
@@ -17,23 +17,33 @@ export interface Patient {
 }
 
 export function PatientCardGrid() {
-  const [patients, setPatients] = useState<Patient[] | null>(null);
+  const [page, setPage] = useState(1);
+  const { data, isLoading } = usePatients(page);
 
-  useEffect(() => {
-    const token = getAuthCookie();
-    if (!token) return;
+  if (isLoading) return <Skeleton className="h-[400px] w-full" />;
 
-    getPatients(token).then((res) => setPatients(res.items));
-  }, []);
-
-  if (!patients) return <Skeleton className="h-[400px] w-full" />;
+  const patients = data?.items ?? [];
   if (patients.length === 0) return <p className="text-muted-foreground">Danışan bulunamadı.</p>;
 
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {patients.map((patient) => (
-        <PatientCard key={patient.id} patient={patient} />
-      ))}
-    </div>
+    <>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {patients.map((patient) => (
+          <PatientCard key={patient.id} patient={patient} />
+        ))}
+      </div>
+      <div className="mt-4 flex justify-center gap-2">
+        <Button variant="outline" disabled={page === 1} onClick={() => setPage((p) => p - 1)}>
+          Önceki
+        </Button>
+        <Button
+          variant="outline"
+          disabled={data && page >= (data.totalPages ?? page)}
+          onClick={() => setPage((p) => p + 1)}
+        >
+          Sonraki
+        </Button>
+      </div>
+    </>
   );
 }

--- a/src/app/(main)/dashboard/patients/_components/patient-card.tsx
+++ b/src/app/(main)/dashboard/patients/_components/patient-card.tsx
@@ -1,45 +1,57 @@
 "use client";
 
 import { useState } from "react";
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogTrigger } from "@/components/ui/dialog";
 import { PatientDialog } from "./patient-dialog";
 import { Patient } from "./patient-card-grid";
+import { usePatientMutations } from "@/hooks/use-patients";
+import { toast } from "sonner";
 
 export function PatientCard({ patient }: { patient: Patient }) {
   const [open, setOpen] = useState(false);
+  const { remove } = usePatientMutations();
+
+  const handleDelete = async () => {
+    if (!patient.id) return;
+    if (!window.confirm("Danışanı silmek istediğinize emin misiniz?")) return;
+    try {
+      await remove.mutateAsync(patient.id);
+      toast.success("Danışan silindi");
+    } catch (err: any) {
+      toast.error(err.message ?? "Silme işlemi başarısız");
+    }
+  };
 
   return (
-    <Card className="flex flex-col justify-between h-full shadow-sm">
+    <Card className="flex h-full flex-col justify-between shadow-sm">
       <CardHeader>
         <CardTitle className="text-lg">{patient.name}</CardTitle>
-        <p className="text-xs text-muted-foreground">{patient.email}</p>
-        <p className="text-xs text-muted-foreground">{patient.phone}</p>
+        <p className="text-muted-foreground text-xs">{patient.email}</p>
+        <p className="text-muted-foreground text-xs">{patient.phone}</p>
       </CardHeader>
 
-      <CardContent className="text-sm text-muted-foreground line-clamp-3">
+      <CardContent className="text-muted-foreground line-clamp-3 text-sm">
         {patient.notes || "Not eklenmemiş."}
       </CardContent>
 
-      <CardFooter className="flex items-center justify-between text-sm text-muted-foreground">
+      <CardFooter className="text-muted-foreground flex items-center justify-between text-sm">
         <span>Son Ziyaret: {patient.lastVisitFormatted}</span>
 
-        <Dialog open={open} onOpenChange={setOpen}>
-          <DialogTrigger asChild>
-            <Button size="sm" variant="outline">
-              Detay
-            </Button>
-          </DialogTrigger>
-          <PatientDialog open={open} onOpenChange={setOpen} patient={patient} />
-        </Dialog>
+        <div className="flex gap-2">
+          <Button size="sm" variant="destructive" onClick={handleDelete}>
+            Sil
+          </Button>
+          <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+              <Button size="sm" variant="outline">
+                Detay
+              </Button>
+            </DialogTrigger>
+            <PatientDialog open={open} onOpenChange={setOpen} patient={patient} />
+          </Dialog>
+        </div>
       </CardFooter>
     </Card>
   );

--- a/src/app/(main)/dashboard/patients/_components/patient-card.tsx
+++ b/src/app/(main)/dashboard/patients/_components/patient-card.tsx
@@ -7,7 +7,9 @@ import { Dialog, DialogTrigger } from "@/components/ui/dialog";
 import { PatientDialog } from "./patient-dialog";
 import { Patient } from "./patient-card-grid";
 import { usePatientMutations } from "@/hooks/use-patients";
-import { toast } from "sonner";
+import { ConfirmDelete } from "@/components/confirm-delete";
+import { notifySuccess, notifyError } from "@/lib/toast";
+import { Trash2, Eye } from "lucide-react";
 
 export function PatientCard({ patient }: { patient: Patient }) {
   const [open, setOpen] = useState(false);
@@ -15,17 +17,31 @@ export function PatientCard({ patient }: { patient: Patient }) {
 
   const handleDelete = async () => {
     if (!patient.id) return;
-    if (!window.confirm("Danışanı silmek istediğinize emin misiniz?")) return;
     try {
       await remove.mutateAsync(patient.id);
-      toast.success("Danışan silindi");
+      notifySuccess("Danışan silindi");
     } catch (err: any) {
-      toast.error(err.message ?? "Silme işlemi başarısız");
+      notifyError(err.message ?? "Silme işlemi başarısız");
     }
   };
 
   return (
-    <Card className="flex h-full flex-col justify-between shadow-sm">
+    <Card className="relative flex h-full flex-col justify-between shadow-sm">
+      <div className="absolute right-2 top-2 flex gap-2">
+        <ConfirmDelete onConfirm={handleDelete}>
+          <Button size="icon" variant="ghost">
+            <Trash2 className="h-4 w-4" />
+          </Button>
+        </ConfirmDelete>
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger asChild>
+            <Button size="icon" variant="outline">
+              <Eye className="h-4 w-4" />
+            </Button>
+          </DialogTrigger>
+          <PatientDialog open={open} onOpenChange={setOpen} patient={patient} />
+        </Dialog>
+      </div>
       <CardHeader>
         <CardTitle className="text-lg">{patient.name}</CardTitle>
         <p className="text-muted-foreground text-xs">{patient.email}</p>
@@ -38,20 +54,6 @@ export function PatientCard({ patient }: { patient: Patient }) {
 
       <CardFooter className="text-muted-foreground flex items-center justify-between text-sm">
         <span>Son Ziyaret: {patient.lastVisitFormatted}</span>
-
-        <div className="flex gap-2">
-          <Button size="sm" variant="destructive" onClick={handleDelete}>
-            Sil
-          </Button>
-          <Dialog open={open} onOpenChange={setOpen}>
-            <DialogTrigger asChild>
-              <Button size="sm" variant="outline">
-                Detay
-              </Button>
-            </DialogTrigger>
-            <PatientDialog open={open} onOpenChange={setOpen} patient={patient} />
-          </Dialog>
-        </div>
       </CardFooter>
     </Card>
   );

--- a/src/app/(main)/dashboard/patients/_components/patient-dialog.tsx
+++ b/src/app/(main)/dashboard/patients/_components/patient-dialog.tsx
@@ -3,7 +3,8 @@
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { PatientForm } from "./patient-form";
-import { toast } from "sonner";
+import { ConfirmDelete } from "@/components/confirm-delete";
+import { notifySuccess, notifyError } from "@/lib/toast";
 import { usePatientMutations } from "@/hooks/use-patients";
 
 interface Props {
@@ -17,13 +18,12 @@ export function PatientDialog({ open, onOpenChange, patient }: Props) {
 
   const handleDelete = async () => {
     if (!patient?.id) return;
-
     try {
       await remove.mutateAsync(patient.id);
-      toast.success("Danışan silindi");
+      notifySuccess("Danışan silindi");
       onOpenChange(false);
     } catch (err: any) {
-      toast.error(err.message ?? "Silme işlemi başarısız");
+      notifyError(err.message ?? "Silme işlemi başarısız");
     }
   };
 
@@ -38,9 +38,11 @@ export function PatientDialog({ open, onOpenChange, patient }: Props) {
 
         {patient && (
           <DialogFooter className="justify-start">
-            <Button variant="destructive" onClick={handleDelete} className="mt-2">
-              Danışanı Sil
-            </Button>
+            <ConfirmDelete onConfirm={handleDelete}>
+              <Button variant="destructive" className="mt-2">
+                Danışanı Sil
+              </Button>
+            </ConfirmDelete>
           </DialogFooter>
         )}
       </DialogContent>

--- a/src/app/(main)/dashboard/patients/_components/patient-dialog.tsx
+++ b/src/app/(main)/dashboard/patients/_components/patient-dialog.tsx
@@ -1,17 +1,10 @@
 "use client";
 
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogFooter,
-} from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { PatientForm } from "./patient-form";
 import { toast } from "sonner";
-import { deletePatient } from "../_services/patient-service";
-import { getAuthCookie } from "@/lib/auth-cookies";
+import { usePatientMutations } from "@/hooks/use-patients";
 
 interface Props {
   open: boolean;
@@ -20,14 +13,13 @@ interface Props {
 }
 
 export function PatientDialog({ open, onOpenChange, patient }: Props) {
+  const { remove } = usePatientMutations();
+
   const handleDelete = async () => {
     if (!patient?.id) return;
 
     try {
-      const token = getAuthCookie();
-      if (!token) return;
-
-      await deletePatient(patient.id, token);
+      await remove.mutateAsync(patient.id);
       toast.success("Danışan silindi");
       onOpenChange(false);
     } catch (err: any) {
@@ -46,11 +38,7 @@ export function PatientDialog({ open, onOpenChange, patient }: Props) {
 
         {patient && (
           <DialogFooter className="justify-start">
-            <Button
-              variant="destructive"
-              onClick={handleDelete}
-              className="mt-2"
-            >
+            <Button variant="destructive" onClick={handleDelete} className="mt-2">
               Danışanı Sil
             </Button>
           </DialogFooter>

--- a/src/app/(main)/dashboard/patients/_components/patient-form.tsx
+++ b/src/app/(main)/dashboard/patients/_components/patient-form.tsx
@@ -8,8 +8,7 @@ import { Button } from "@/components/ui/button";
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
 import { Textarea } from "@/components/ui/textarea";
 import { toast } from "sonner";
-import { createPatient, updatePatient } from "../_services/patient-service";
-import { getAuthCookie } from "@/lib/auth-cookies";
+import { usePatientMutations } from "@/hooks/use-patients";
 
 const schema = z.object({
   name: z.string().min(2),
@@ -19,13 +18,7 @@ const schema = z.object({
   notes: z.string().optional(),
 });
 
-export function PatientForm({
-  patient,
-  onSuccess,
-}: {
-  patient?: any;
-  onSuccess?: () => void;
-}) {
+export function PatientForm({ patient, onSuccess }: { patient?: any; onSuccess?: () => void }) {
   const form = useForm({
     resolver: zodResolver(schema),
     defaultValues: patient ?? {
@@ -37,16 +30,15 @@ export function PatientForm({
     },
   });
 
+  const { create, update } = usePatientMutations();
+
   const onSubmit = async (values: any) => {
     try {
-      const token = getAuthCookie();
-    if (!token) return;
-
       if (patient) {
-        await updatePatient(patient.id, values, token);
+        await update.mutateAsync({ id: patient.id, data: values });
         toast.success("Danışan güncellendi");
       } else {
-        await createPatient(values, token);
+        await create.mutateAsync(values);
         toast.success("Danışan eklendi");
       }
 
@@ -59,41 +51,71 @@ export function PatientForm({
   return (
     <Form {...form}>
       <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-        <FormField control={form.control} name="name" render={({ field }) => (
-          <FormItem>
-            <FormLabel>Ad Soyad</FormLabel>
-            <FormControl><Input {...field} /></FormControl>
-            <FormMessage />
-          </FormItem>
-        )} />
-        <FormField control={form.control} name="age" render={({ field }) => (
-          <FormItem>
-            <FormLabel>Yaş</FormLabel>
-            <FormControl><Input type="number" {...field} /></FormControl>
-            <FormMessage />
-          </FormItem>
-        )} />
-        <FormField control={form.control} name="email" render={({ field }) => (
-          <FormItem>
-            <FormLabel>Email</FormLabel>
-            <FormControl><Input type="email" {...field} /></FormControl>
-            <FormMessage />
-          </FormItem>
-        )} />
-        <FormField control={form.control} name="phone" render={({ field }) => (
-          <FormItem>
-            <FormLabel>Telefon</FormLabel>
-            <FormControl><Input {...field} /></FormControl>
-            <FormMessage />
-          </FormItem>
-        )} />
-        <FormField control={form.control} name="notes" render={({ field }) => (
-          <FormItem>
-            <FormLabel>Not</FormLabel>
-            <FormControl><Textarea {...field} /></FormControl>
-            <FormMessage />
-          </FormItem>
-        )} />
+        <FormField
+          control={form.control}
+          name="name"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Ad Soyad</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="age"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Yaş</FormLabel>
+              <FormControl>
+                <Input type="number" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="email"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Email</FormLabel>
+              <FormControl>
+                <Input type="email" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="phone"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Telefon</FormLabel>
+              <FormControl>
+                <Input {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="notes"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Not</FormLabel>
+              <FormControl>
+                <Textarea {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
         <Button type="submit" className="w-full">
           {patient ? "Güncelle" : "Kaydet"}
         </Button>

--- a/src/app/(main)/dashboard/patients/_components/patient-form.tsx
+++ b/src/app/(main)/dashboard/patients/_components/patient-form.tsx
@@ -7,7 +7,7 @@ import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
 import { Textarea } from "@/components/ui/textarea";
-import { toast } from "sonner";
+import { notifySuccess, notifyError } from "@/lib/toast";
 import { usePatientMutations } from "@/hooks/use-patients";
 
 const schema = z.object({
@@ -36,15 +36,15 @@ export function PatientForm({ patient, onSuccess }: { patient?: any; onSuccess?:
     try {
       if (patient) {
         await update.mutateAsync({ id: patient.id, data: values });
-        toast.success("Danışan güncellendi");
+        notifySuccess("Danışan güncellendi");
       } else {
         await create.mutateAsync(values);
-        toast.success("Danışan eklendi");
+        notifySuccess("Danışan eklendi");
       }
 
       onSuccess?.();
     } catch (err: any) {
-      toast.error(err.message ?? "İşlem başarısız");
+      notifyError(err.message ?? "İşlem başarısız");
     }
   };
 

--- a/src/app/(main)/dashboard/patients/_services/patient-service.ts
+++ b/src/app/(main)/dashboard/patients/_services/patient-service.ts
@@ -2,8 +2,8 @@ import { APP_CONFIG } from "@/config/app-config";
 
 const BASE_URL = `${APP_CONFIG.api.baseUrl}/patients`;
 
-export async function getPatients(token: string) {
-  const res = await fetch(`${BASE_URL}?PageNumber=1&PageSize=10`, {
+export async function getPatients(token: string, page = 1) {
+  const res = await fetch(`${BASE_URL}?PageNumber=${page}&PageSize=9`, {
     headers: {
       Accept: "application/json",
       "Content-Type": "application/json",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 
 import { Toaster } from "@/components/ui/sonner";
+import QueryProvider from "@/providers/query-provider";
 import { APP_CONFIG } from "@/config/app-config";
 import { getPreference } from "@/server/server-actions";
 import { ThemeMode, allowedThemeModes, ThemePreset, allowedThemePresets } from "@/types/preferences";
@@ -29,7 +30,7 @@ export default async function RootLayout({ children }: Readonly<{ children: Reac
       suppressHydrationWarning
     >
       <body className={`${inter.className} min-h-screen antialiased`}>
-        {children}
+        <QueryProvider>{children}</QueryProvider>
         <Toaster />
       </body>
     </html>

--- a/src/components/confirm-delete.tsx
+++ b/src/components/confirm-delete.tsx
@@ -1,0 +1,38 @@
+import {
+  AlertDialog,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from "@/components/ui/alert-dialog";
+import { ReactNode } from "react";
+
+interface ConfirmDeleteProps {
+  children: ReactNode;
+  onConfirm: () => void | Promise<void>;
+  description?: string;
+}
+
+export function ConfirmDelete({ children, onConfirm, description }: ConfirmDeleteProps) {
+  return (
+    <AlertDialog>
+      <AlertDialogTrigger asChild>{children}</AlertDialogTrigger>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Silme İşlemi</AlertDialogTitle>
+          <AlertDialogDescription>
+            {description ?? "Bu işlem geri alınamaz. Devam etmek istiyor musunuz?"}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Vazgeç</AlertDialogCancel>
+          <AlertDialogAction onClick={onConfirm}>Sil</AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/hooks/use-patients.ts
+++ b/src/hooks/use-patients.ts
@@ -1,0 +1,47 @@
+"use client";
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { getAuthCookie } from "@/lib/auth-cookies";
+import {
+  getPatients,
+  createPatient,
+  updatePatient,
+  deletePatient,
+} from "@/app/(main)/dashboard/patients/_services/patient-service";
+
+export function usePatients(page: number) {
+  const token = getAuthCookie();
+  return useQuery({
+    queryKey: ["patients", page],
+    queryFn: () => (token ? getPatients(token, page) : Promise.resolve(null)),
+    enabled: !!token,
+  });
+}
+
+export function usePatientMutations() {
+  const queryClient = useQueryClient();
+  const token = getAuthCookie();
+
+  const create = useMutation({
+    mutationFn: (data: any) => createPatient(data, token!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["patients"] });
+    },
+  });
+
+  const update = useMutation({
+    mutationFn: ({ id, data }: { id: string; data: any }) => updatePatient(id, data, token!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["patients"] });
+    },
+  });
+
+  const remove = useMutation({
+    mutationFn: (id: string) => deletePatient(id, token!),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["patients"] });
+    },
+  });
+
+  return { create, update, remove };
+}

--- a/src/lib/toast.ts
+++ b/src/lib/toast.ts
@@ -1,0 +1,4 @@
+import { toast } from "sonner";
+
+export const notifySuccess = (message: string) => toast.success(message);
+export const notifyError = (message: string) => toast.error(message);

--- a/src/providers/query-provider.tsx
+++ b/src/providers/query-provider.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactNode, useState } from "react";
+
+export default function QueryProvider({ children }: { children: ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}


### PR DESCRIPTION
## Summary
- use React Query to refetch patient data automatically
- expose query client provider in `RootLayout`
- add hooks for patient CRUD and use them in UI
- show Delete button on cards and support pagination

## Testing
- `npm run lint` *(fails: Next.js plugin not detected)*
- `npm run build` *(fails during lint step)*

------
https://chatgpt.com/codex/tasks/task_e_68765023b3ec8320ab332d6b4362194a